### PR TITLE
Limit to single admin for HP Admin API proposal compatibility

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -56,7 +56,7 @@ pub enum Config {
     V1 {
         #[serde(deserialize_with = "seed_from_base64", serialize_with = "to_base64")]
         seed: Seed,
-        admins: Vec<Admin>,
+        admin: Admin,
     },
 }
 
@@ -81,7 +81,7 @@ impl Config {
 
         Ok((
             Config::V1 {
-                admins: vec![admin],
+                admin: admin,
                 seed: seed,
             },
             holochain_public_key,


### PR DESCRIPTION
We need to be able to update this data via POST `/v1/config` HP Admin API endpoint, and it'll be more verbose to update it as a list.

Additionally, https://github.com/Holo-Host/rfcs/pull/2 has been written with single Admin in mind, and possibility of having multiple admins isn't being accounted for in current HP Admin UI.

Marking as a draft until #6 is merged.