### PR TITLE
Add GitHub Actions CI to Cloudflare Workers Sites

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - master
+jobs:
+  gen-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: cachix/install-nix-action@v6
+      - run: |
+          nix-shell \
+            --option substituters 'https://cache.holo.host/ https://cache.nixos.org/' \
+            --option trusted-public-keys \
+              'cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE=
+               cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=' \
+            --run 'cd gen-web; npm install; npm run build; wrangler publish'
+        env:
+          CF_API_TOKEN: ${{ secrets.cf_api_token }}

--- a/gen-web/workers-site/index.js
+++ b/gen-web/workers-site/index.js
@@ -1,0 +1,15 @@
+import { getAssetFromKV } from '@cloudflare/kv-asset-handler'
+
+const handleEvent = event => async {
+  let url = new URL(event.request.url)
+  if (url.protocol === 'http:') {
+    url.protocol.set('https:')
+    return Response.redirect(url.href, 301)
+  }
+
+  return getAssetFromKV(event)
+};
+
+addEventListener('fetch', event => {
+  event.respondWith(handleEvent(event))
+})

--- a/gen-web/workers-site/package-lock.json
+++ b/gen-web/workers-site/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@cloudflare/kv-asset-handler": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.0.5.tgz",
+      "integrity": "sha512-7yLMAUZD1XQNKzmktYCcUUPB+wXmQENv1MMi8QEMs0rzL01e0XEyCUUDauRXHzxi7dBbSUGA5RS23h890ncKog==",
+      "requires": {
+        "mime": "^2.4.4"
+      }
+    },
+    "mime": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+    }
+  }
+}

--- a/gen-web/workers-site/package.json
+++ b/gen-web/workers-site/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "index.js",
+  "dependencies": {
+    "@cloudflare/kv-asset-handler": "^0.0.5"
+  }
+}

--- a/gen-web/wrangler.toml
+++ b/gen-web/wrangler.toml
@@ -1,0 +1,12 @@
+account_id = "18ff2b4e6205b938652998cfca0d8cff"
+zone_id = "35f34e8f9d04ef8c87283ea9fb812989"
+
+name = "hpos-config-gen-web"
+route = "quickstart.holo.host/*"
+
+type = "webpack"
+webpack_config = "webpack.config.js"
+
+[site]
+bucket = "./dist"
+entry-point = "workers-site"

--- a/shell.nix
+++ b/shell.nix
@@ -4,4 +4,6 @@ with pkgs;
 
 mkShell {
   inputsFrom = lib.attrValues (import ./. { inherit pkgs; });
+
+  buildInputs = [ wrangler ];
 }


### PR DESCRIPTION
This will replace current deployment with Cloudflare Workers Sites. `master` branch will be deployed to <https://quickstart.holo.host>. Once this is merged to `develop`, also open a PR from `develop` to `master` to make the first deployment.